### PR TITLE
放弃本地修改强制更新

### DIFF
--- a/shell/docker-entrypoint.sh
+++ b/shell/docker-entrypoint.sh
@@ -42,7 +42,7 @@ fi
 
 
 echo "git pull拉取最新代码..."
-cd $CODE_DIR && git reset --hard && git pull;
+cd $CODE_DIR && git fetch --all && git reset --hard origin/master && git pull;
 echo "pip install 安装最新依赖..."
 pip install -r $CODE_DIR/requirements.txt
 echo "更新docker-entrypoint..."


### PR DESCRIPTION
修改了仓库下文件权限或者其他内容时会无法更新。
修改使用git fetch 先更新远程仓库，然后强制更新本地仓库。
